### PR TITLE
Rubygems/Contribute will not run in Linux

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'http://rubygems.org'
 
 gem 'rails', '3.1.1'
 
+#if HOST_OS =~ /linux/i
+  gem 'therubyracer', '>= 0.9.8'
+#end
+
 gem 'flutie'
 gem 'high_voltage'
 gem 'jquery-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 require 'rbconfig'
 HOST_OS = RbConfig::CONFIG['host_os']
-
 source 'http://rubygems.org'
-
 gem 'rails', '3.1.1'
 
 if HOST_OS =~ /linux/i

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,13 @@
+require 'rbconfig'
+HOST_OS = RbConfig::CONFIG['host_os']
+
 source 'http://rubygems.org'
 
 gem 'rails', '3.1.1'
 
-#if HOST_OS =~ /linux/i
+if HOST_OS =~ /linux/i
   gem 'therubyracer', '>= 0.9.8'
-#end
+end
 
 gem 'flutie'
 gem 'high_voltage'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       railties (~> 3.0)
       thor (~> 0.14)
     json (1.6.1)
+    libv8 (3.3.10.4)
     mail (2.3.0)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -95,6 +96,8 @@ GEM
       hike (~> 1.2)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
+    therubyracer (0.9.9)
+      libv8 (~> 3.3.10)
     thor (0.14.6)
     tilt (1.3.3)
     treetop (1.4.10)
@@ -116,4 +119,5 @@ DEPENDENCIES
   rails (= 3.1.1)
   redcarpet
   sass-rails (~> 3.1.4)
+  therubyracer (>= 0.9.8)
   uglifier (>= 1.0.3)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,35 @@ This is a Rails 3.1 app that is deployed to Heroku. Get the app running on your 
 
 Done! There's no database requirement (in fact, ActiveRecord is not loaded at all!) so setup should go smoothly.
 
+Setup for Ubuntu
+================
+
+Ubuntu needs a JavaScript runtime. It says: 
+    Ubuntu Could not find a JavaScript runtime. 
+      See https://github.com/sstephenson/execjs 
+      for a list of available runtimes. 
+      (ExecJS::RuntimeUnavailable)
+
+So modify the Gemfile before you run bundle.  The gemfile should look like this:
+
+    source 'http://rubygems.org'
+    .            
+    .            
+    .            
+    gem 'rails', '3.1.1'
+    gem 'therubyrunner'
+    .            
+    .            
+    .            
+    gem 'uglifier', '>= 1.0.3'
+
+Then, run the same 2 commands shown above:
+
+    bundle
+    rails server
+
+Now, rails and rake should run for you in ubuntu
+
 Adding links
 ============
 

--- a/README.md
+++ b/README.md
@@ -19,26 +19,35 @@ This is a Rails 3.1 app that is deployed to Heroku. Get the app running on your 
 
 Done! There's no database requirement (in fact, ActiveRecord is not loaded at all!) so setup should go smoothly.
 
-Setup for Ubuntu
+Setup for Linux
 ================
 
-Ubuntu needs a JavaScript runtime. It says: 
-    Ubuntu Could not find a JavaScript runtime. 
+For Rails 3.1, Linux must have a JavaScript runtime. 
+Without one Rails says:  
+    Linux Could not find a JavaScript runtime. 
       See https://github.com/sstephenson/execjs 
       for a list of available runtimes. 
       (ExecJS::RuntimeUnavailable)
 
 So modify the Gemfile before you run bundle.  The gemfile should look like this:
 
+
+    require 'rbconfig'
+    HOST_OS = RbConfig::CONFIG['host_os']
     source 'http://rubygems.org'
-    .            
-    .            
-    .            
     gem 'rails', '3.1.1'
-    gem 'therubyrunner'
-    .            
-    .            
-    .            
+
+    if HOST_OS =~ /linux/i
+      gem 'therubyracer', '>= 0.9.8'
+    end
+
+    gem 'flutie'
+    gem 'high_voltage'
+    gem 'jquery-rails'
+    gem 'redcarpet'
+
+    gem 'sass-rails',   '~> 3.1.4'
+    gem 'coffee-rails', '~> 3.1.1'
     gem 'uglifier', '>= 1.0.3'
 
 Then, run the same 2 commands shown above:


### PR DESCRIPTION
Linux requres an additional gem for Rails 3.1 applications.  It is a runtime for ExecJS.

I have modified the Rubygems/Contribute README file and the Gemfile.

I have tested it on my ubuntu system but not on OSX.
